### PR TITLE
Replacing gf_struct_t by vector<pair<string, variant<int, string>>>

### DIFF
--- a/benchmark/5+5/5_plus_5.py
+++ b/benchmark/5+5/5_plus_5.py
@@ -1,13 +1,15 @@
 #!/bin/env pytriqs
 
+import inspect
 import pytriqs.utility.mpi as mpi
 from pytriqs.archive import HDFArchive
 from pytriqs.operators import *
 from pytriqs.operators.util.op_struct import set_operator_structure, get_mkind
 from pytriqs.operators.util.U_matrix import cubic_names, U_matrix
 from pytriqs.operators.util.hamiltonians import h_int_slater
-from pytriqs.applications.impurity_solvers.cthyb import *
-from pytriqs.gf import *
+from triqs_cthyb import SolverCore
+import triqs_cthyb.version as version
+from pytriqs.gf import GfImFreq, iOmega_n, inverse
 from itertools import product
 
 def five_plus_five(use_interaction=True):
@@ -66,7 +68,7 @@ def five_plus_five(use_interaction=True):
     p["n_warmup_cycles"] = 1000
     p["n_cycles"] = 30000
     p["partition_method"] = "autopartition"
-    p["measure_g_tau"] = True
+    p["measure_G_tau"] = True
     p["move_shift"] = True
     p["measure_pert_order"] = False
     p["performance_analysis"] = False
@@ -130,13 +132,10 @@ def five_plus_five(use_interaction=True):
         Results['spin_names'] = spin_names
         Results['orb_names'] = orb_names
 
-        import pytriqs.applications.impurity_solvers.cthyb.version as version
-        import inspect
         import __main__
         Results.create_group("log")
         log = Results["log"]
         log["version"] = version.version
-        #log["release"] = version.release
         log["triqs_hash"] = version.triqs_hash
         log["cthyb_hash"] = version.cthyb_hash
         log["script"] = inspect.getsource(__main__)

--- a/benchmark/anderson/anderson.py
+++ b/benchmark/anderson/anderson.py
@@ -4,8 +4,9 @@ import itertools
 import pytriqs.utility.mpi as mpi
 from pytriqs.archive import HDFArchive
 from pytriqs.operators import *
-from pytriqs.applications.impurity_solvers.cthyb import *
-from pytriqs.gf import *
+from triqs_cthyb import SolverCore
+from pytriqs.atom_diag import trace_rho_op
+from pytriqs.gf import GfImFreq, iOmega_n, inverse
 
 def anderson(use_qn=True, use_blocks=True):
 
@@ -53,6 +54,8 @@ def anderson(use_qn=True, use_blocks=True):
         bn, i = mkind(spin)
         gf_struct.setdefault(bn,[]).append(i)
 
+    gf_struct = [ [key, value] for key, value in gf_struct.items() ] # convert from dict to list of lists
+            
     mpi.report("Constructing the solver...")
 
     # Construct the solver

--- a/benchmark/asymm_bath/asymm_bath.py
+++ b/benchmark/asymm_bath/asymm_bath.py
@@ -1,10 +1,10 @@
 #!/bin/env pytriqs
 
 import pytriqs.utility.mpi as mpi
-from pytriqs.gf import *
-from pytriqs.operators import *
+from pytriqs.gf import GfImFreq, iOmega_n, inverse
+from pytriqs.operators import n
 from pytriqs.archive import HDFArchive
-from pytriqs.applications.impurity_solvers.cthyb import *
+from triqs_cthyb import SolverCore
 
 mpi.report("Welcome to asymm_bath test (1 band with a small asymmetric hybridization function).")
 mpi.report("This test helps to detect sampling problems.")
@@ -32,7 +32,7 @@ p["performance_analysis"] = True
 p["measure_pert_order"] = True
 
 # Block structure of GF
-gf_struct = {'up':[0], 'dn':[0]}
+gf_struct = [['up', [0]], ['dn', [0]]]
 
 # Hamiltonian
 H = U*n("up",0)*n("dn",0)

--- a/benchmark/autopartition/autopartition.py
+++ b/benchmark/autopartition/autopartition.py
@@ -1,12 +1,12 @@
 #!/bin/env pytriqs
 
 import time
-from pytriqs.gf.local import *
+from pytriqs.gf import iOmega_n, inverse
 from pytriqs.operators import *
 from pytriqs.operators.util.op_struct import set_operator_structure, get_mkind
 from pytriqs.operators.util.U_matrix import U_matrix
 from pytriqs.operators.util.hamiltonians import h_int_kanamori, h_int_slater
-from pytriqs.applications.impurity_solvers.cthyb import *
+from triqs_cthyb import *
 import numpy as np
 
 spin_names = ("up","dn")

--- a/benchmark/kanamori/kanamori.py
+++ b/benchmark/kanamori/kanamori.py
@@ -2,11 +2,11 @@
 
 import pytriqs.utility.mpi as mpi
 from pytriqs.archive import HDFArchive
-from pytriqs.operators import *
+from pytriqs.operators import n, Operator
 from pytriqs.operators.util.op_struct import set_operator_structure, get_mkind
 from pytriqs.operators.util.hamiltonians import h_int_kanamori
-from pytriqs.applications.impurity_solvers.cthyb import *
-from pytriqs.gf import *
+from triqs_cthyb import SolverCore
+from pytriqs.gf import GfImFreq, iOmega_n, inverse
 import numpy as np
 
 # Input parameters

--- a/benchmark/kanamori_offdiag/kanamori_offdiag.py
+++ b/benchmark/kanamori_offdiag/kanamori_offdiag.py
@@ -2,11 +2,11 @@
 
 import pytriqs.utility.mpi as mpi
 from pytriqs.archive import HDFArchive
-from pytriqs.operators import *
+from pytriqs.operators import n, Operator
 from pytriqs.operators.util.op_struct import set_operator_structure, get_mkind
 from pytriqs.operators.util.hamiltonians import h_int_kanamori
-from pytriqs.applications.impurity_solvers.cthyb import *
-from pytriqs.gf import *
+from triqs_cthyb import SolverCore
+from pytriqs.gf import GfImFreq, iOmega_n, inverse
 import numpy as np
 
 # Input parameters

--- a/benchmark/legendre/legendre.py
+++ b/benchmark/legendre/legendre.py
@@ -2,9 +2,9 @@
 
 import pytriqs.utility.mpi as mpi
 from pytriqs.archive import HDFArchive
-from pytriqs.operators import *
-from pytriqs.applications.impurity_solvers.cthyb import *
-from pytriqs.gf import *
+from triqs_cthyb import SolverCore
+from pytriqs.operators import n
+from pytriqs.gf import GfImFreq, iOmega_n, inverse
 
 spin_names = ("up","dn")
 def mkind(spin): return (spin,0)
@@ -29,8 +29,8 @@ p["random_seed"] = 123 * mpi.rank + 567
 p["length_cycle"] = 50
 p["n_warmup_cycles"] = 50000
 p["n_cycles"] = 5000000
-p["measure_g_tau"] = False
-p["measure_g_l"] = True
+p["measure_G_tau"] = False
+p["measure_G_l"] = True
 
 results_file_name = "legendre.h5"
 
@@ -45,6 +45,7 @@ gf_struct = {}
 for spin in spin_names:
     bn, i = mkind(spin)
     gf_struct.setdefault(bn,[]).append(i)
+gf_struct = [ [key, value] for key, value in gf_struct.items() ]
 
 mpi.report("Constructing the solver...")
 

--- a/benchmark/move_global/move_global.py
+++ b/benchmark/move_global/move_global.py
@@ -2,14 +2,15 @@
 
 import pytriqs.utility.mpi as mpi
 from pytriqs.archive import HDFArchive
-from pytriqs.operators import *
-from pytriqs.applications.impurity_solvers.cthyb import *
-from pytriqs.gf import *
+from pytriqs.operators import n
+from pytriqs.atom_diag import trace_rho_op
+from triqs_cthyb import SolverCore
+from pytriqs.gf import GfImFreq, iOmega_n, inverse
 import numpy as np
 
 spin_names = ("up","dn")
 mkind = lambda sn, on: (sn,on)
-gf_struct = {"up":[1,2], "dn":[1,2]}
+gf_struct = [ ["up", [1, 2]], ["dn", [1, 2]] ]
 
 # Input parameters
 beta = 100.0
@@ -29,7 +30,7 @@ p["random_seed"] = 123 * mpi.rank + 567
 p["length_cycle"] = 50
 p["n_warmup_cycles"] = 100000
 p["n_cycles"] = 1000000
-p["measure_g_tau"] = True
+p["measure_G_tau"] = True
 p["measure_density_matrix"] = True
 p["use_norm_as_weight"] = True
 

--- a/benchmark/nonint/nonint.py
+++ b/benchmark/nonint/nonint.py
@@ -2,9 +2,9 @@
 
 import pytriqs.utility.mpi as mpi
 from pytriqs.archive import HDFArchive
-from pytriqs.applications.impurity_solvers.cthyb import *
-from pytriqs.operators import *
-from pytriqs.gf import *
+from triqs_cthyb import SolverCore
+from pytriqs.operators import Operator, n
+from pytriqs.gf import GfImFreq, inverse, iOmega_n
 
 mpi.report("Welcome to nonint (non-interacting many-band systems) test.")
 mpi.report("This test is aimed to reveal excessive state truncation issues.")
@@ -27,17 +27,18 @@ for modes in range(1,N_max+1):
     V = [0.2]*modes
     e = [-0.2]*modes
 
-    gf_struct = {str(n):[0] for n in range(0,len(V))}
+    #gf_struct = {str(n):[0] for n in range(0,len(V))}
+    gf_struct = [ [str(bidx), [0]] for bidx in range(0,len(V)) ]
 
     # Local Hamiltonian
     H = Operator()
 
     # Quantum numbers (N_up and N_down)
     QN = []
-    for b in sorted(gf_struct.keys()): QN.append(n(b,0))
+    for b, idxs in gf_struct: QN.append(n(b,0))
     p["partition_method"] = "quantum_numbers"
     p["quantum_numbers"] = QN
-
+    
     mpi.report("Constructing the solver...")
 
     # Construct the solver
@@ -46,7 +47,8 @@ for modes in range(1,N_max+1):
     mpi.report("Preparing the hybridization function...")
 
     # Set hybridization function
-    for m, b in enumerate(sorted(gf_struct.keys())):
+    #for m, b in enumerate(sorted(gf_struct.keys())):
+    for m, (b, idxs) in enumerate(gf_struct):
         delta_w = GfImFreq(indices = [0], beta=beta)
         delta_w << (V[m]**2) * inverse(iOmega_n - e[m])
         S.G0_iw[b][0,0] << inverse(iOmega_n - e[m] - delta_w)

--- a/benchmark/spinless/spinless.py
+++ b/benchmark/spinless/spinless.py
@@ -4,9 +4,9 @@ import numpy as np
 
 import pytriqs.utility.mpi as mpi
 from pytriqs.archive import HDFArchive
-from pytriqs.applications.impurity_solvers.cthyb import *
-from pytriqs.operators import *
-from pytriqs.gf import *
+from triqs_cthyb import SolverCore
+from pytriqs.operators import n
+from pytriqs.gf import GfImFreq, iOmega_n, inverse
 
 def run_calculation(use_qn=True):
 
@@ -42,7 +42,7 @@ def run_calculation(use_qn=True):
         p["partition_method"] = "quantum_numbers"
         p["quantum_numbers"] = QN
 
-    gf_struct = {"tot":["A","B"]}
+    gf_struct = [["tot", ["A","B"]]]
 
     mpi.report("Constructing the solver...")
 

--- a/cthyb/measures/util.hpp
+++ b/cthyb/measures/util.hpp
@@ -68,8 +68,9 @@ namespace cthyb {
         }
       } else { // Check the blocks we've been asked to measure
         for (auto const &bn : G2_blocks_to_measure) {
-          if (!gf_struct.count(bn.first)) TRIQS_RUNTIME_ERROR << "Invalid left block name " << bn.first << " for G^2 measurement";
-          if (!gf_struct.count(bn.second)) TRIQS_RUNTIME_ERROR << "Invalid right block name " << bn.second << " for G^2 measurement";
+	  auto count_bl = [&gf_struct](auto bl_name){ return std::count_if(gf_struct.cbegin(), gf_struct.cend(), [&bl_name](auto & bl){ return bl.first == bl_name; }); };
+          if (count_bl(bn.first) != 1) TRIQS_RUNTIME_ERROR << "Invalid left block name " << bn.first << " for G^2 measurement";
+          if (count_bl(bn.second) != 1) TRIQS_RUNTIME_ERROR << "Invalid right block name " << bn.second << " for G^2 measurement";
         }
       }
 

--- a/cthyb/types.hpp
+++ b/cthyb/types.hpp
@@ -2,7 +2,7 @@
  *
  * TRIQS: a Toolbox for Research in Interacting Quantum Systems
  *
- * Copyright (C) 2017, H. U.R. Strand
+ * Copyright (C) 2017, H. U.R. Strand, N. Wentzell
  *
  * TRIQS is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
@@ -50,6 +50,7 @@ namespace cthyb {
 
   using atom_diag = triqs::atom_diag::atom_diag<is_h_scalar_complex>;
 
+  using triqs::hilbert_space::gf_struct_t;
   using triqs::utility::time_pt;
   using op_t        = std::pair<time_pt, int>;
   using histo_map_t = std::map<std::string, histogram>;
@@ -93,10 +94,8 @@ namespace cthyb {
 namespace triqs {
   namespace gfs {
 
-    /// The structure of the gf : block_name -> [...]= list of indices (int/string). FIXME Change to pair of vec<str> and vec<int> or vec<pair<str,int>>
-    using block_gf_structure_t = std::map<std::string, std::vector<std::variant<int, std::string>>>;
     /// Function template for block_gf initialization
-    template <typename Val_t, typename Var_t> block_gf<Var_t, Val_t> make_block_gf(gf_mesh<Var_t> const &m, block_gf_structure_t const &gf_struct) {
+    template <typename Val_t, typename Var_t> block_gf<Var_t, Val_t> make_block_gf(gf_mesh<Var_t> const &m, triqs::hilbert_space::gf_struct_t const &gf_struct) {
 
       std::vector<gf<Var_t, Val_t>> gf_vec;
       std::vector<std::string> block_names;
@@ -115,13 +114,13 @@ namespace triqs {
     }
 
     // default to matrix_valued gf
-    template <typename Var_t> block_gf<Var_t, matrix_valued> make_block_gf(gf_mesh<Var_t> const &m, block_gf_structure_t const &gf_struct) {
+    template <typename Var_t> block_gf<Var_t, matrix_valued> make_block_gf(gf_mesh<Var_t> const &m, triqs::hilbert_space::gf_struct_t const &gf_struct) {
       return make_block_gf<matrix_valued, Var_t>(m, gf_struct);
     }
 
     /// Function template for block2_gf initialization
     template <typename Var_t>
-    block2_gf<Var_t, tensor_valued<4>> make_block2_gf(gf_mesh<Var_t> const &m, block_gf_structure_t const &gf_struct,
+    block2_gf<Var_t, tensor_valued<4>> make_block2_gf(gf_mesh<Var_t> const &m, triqs::hilbert_space::gf_struct_t const &gf_struct,
                                                       cthyb::block_order order = cthyb::block_order::AABB) {
 
       std::vector<std::vector<gf<Var_t, tensor_valued<4>>>> gf_vecvec;

--- a/doc/guide/aim.py
+++ b/doc/guide/aim.py
@@ -10,7 +10,7 @@ e_f, beta = -U/2.0, 50
 
 # Construct the impurity solver with the inverse temperature
 # and the structure of the Green's functions
-S = Solver(beta = beta, gf_struct = {'up':[0], 'down':[0]}, n_l = 100)
+S = Solver(beta = beta, gf_struct = [ ['up',[0]], ['down',[0]] ], n_l = 100)
 
 # Initialize the non-interacting Green's function S.G0_iw
 for name, g0 in S.G0_iw: g0 << inverse(iOmega_n - e_f - V**2 * Wilson(D))

--- a/doc/guide/aim.rst
+++ b/doc/guide/aim.rst
@@ -60,7 +60,7 @@ in more detail in the section :ref:`ctqmc_ref`. Basically, the constructor
 of the Solver needs two keywords:
 
 - ``beta``: the inverse temperature,
-- ``gf_struct``: a dictionary {str:list} describing the block structure of the Green's function.
+- ``gf_struct``: a list of pairs [ [str:[int,...]], ...] describing the block structure of the Green's function.
 
 This ensures that all quantities within Solver are correctly initialised,
 and in particular that the block structure of all Green's function objects is consistent.

--- a/doc/guide/dmft.py
+++ b/doc/guide/dmft.py
@@ -12,7 +12,7 @@ beta = 100
 n_loops = 5
 
 # Construct the CTQMC solver
-S = Solver(beta = beta, gf_struct = {'up':[0], 'down':[0]})
+S = Solver(beta = beta, gf_struct = [ ['up',[0]], ['down',[0]] ])
 
 # Initalize the Green's function to a semi circular DOS
 S.G_iw << SemiCircular(half_bandwidth)

--- a/doc/guide/settingparameters.rst
+++ b/doc/guide/settingparameters.rst
@@ -24,8 +24,8 @@ correct structure of the Green's function for the problem you are considering.
 You should always try to take advantage of a possible block structure of the
 Green's function. In a spin-conserving system, the Green's function can often
 be (at least) cut into *up* and *down* spin sectors.  When the structure is
-clear you can set the parameter ``gf_struct``, which is a ``dict()`` mapping a
-string that gives the name of the block to a list of the indices of the block.
+clear you can set the parameter ``gf_struct``, which is a ``list()`` or pairs,
+each containing the name of the block and a list of the indices of the block.
 
 Examples
 ........
@@ -33,12 +33,12 @@ Examples
 * For a single-band Hubbard model with a local Coulomb interaction, the Green's function
   can be cut in two up/down blocks of size 1. We would have::
 
-    gf_struct = { 'up': [0], 'down': [0] }
+    gf_struct = [ ['up',[0]], ['down',[0]] ]
 
 * For a two-band Hubbard model with a hybridization between the bands, the Green's function
   can be cut in two up/down blocks, but there are off-diagonal orbital elements. We have::
 
-    gf_struct = { 'up': [0,1], 'down': [0,1] }
+    gf_struct = [ ['up',[0, 1]], ['down',[0, 1]] ]
 
 
 Step 2 - the Hamiltonian

--- a/doc/guide/several_random.py
+++ b/doc/guide/several_random.py
@@ -8,7 +8,7 @@ D, V, U = 1.0, 0.2, 4.0
 e_f, beta = -U/2.0, 50
 
 # Construct the impurity solver
-S = Solver(beta = beta, gf_struct = {'up':[0],'down':[0]})
+S = Solver(beta = beta, gf_struct = [ ['up',[0]], ['down',[0]] ])
 
 # Loop for two random generators
 for random_name in ['mt11213b','lagged_fibonacci607']:

--- a/doc/guide/slater_five_band.py
+++ b/doc/guide/slater_five_band.py
@@ -26,7 +26,7 @@ p["length_cycle"] = 500          # Number of MC steps between consecutive measur
 p["move_double"] = True          # Use four-operator moves
 
 # Block structure of Green's functions
-# gf_struct = {'up':[0,1,2,3,4], 'down':[0,1,2,3,4]}
+# gf_struct = [ ['up',[0,1,2,3,4]], ['down',[0,1,2,3,4]] ]
 # This can be computed using the TRIQS function as follows:
 gf_struct = op.set_operator_structure(spin_names,orb_names,off_diag=off_diag) 
 

--- a/doc/guide/static.py
+++ b/doc/guide/static.py
@@ -12,7 +12,7 @@ beta = 50       # Inverse temperature
 
 # Construct the impurity solver with the inverse temperature
 # and the structure of the Green's functions
-S = Solver(beta = beta, gf_struct = {'up':[0], 'down':[0]})
+S = Solver(beta = beta, gf_struct = [ ['up',[0]], ['down',[0]] ])
 
 # Initialize the non-interacting Green's function S.G0_iw
 # External magnetic field introduces Zeeman energy splitting between

--- a/python/cthyb/solver.py
+++ b/python/cthyb/solver.py
@@ -13,12 +13,12 @@ class Solver(SolverCore):
         ----------
         beta : scalar
                Inverse temperature.
-        gf_struct : dict{str:list}
+        gf_struct : list of pairs [ [str,[int,...]], ...]
                     Structure of the Green's functions. It must be a
-                    dictionary, which maps the name of each block of the
-                    Green's function as a string to a list of integer
+                    list of pairs, each containing the name of the
+                    Green's function block as a string and a list of integer
                     indices.
-                    For example: ``{'up': [1,2,3], 'down', [1,2,3]}``.
+                    For example: ``[ ['up', [0, 1, 2]], ['down', [0, 1, 2]] ]``.
         n_iw : integer, optional
                Number of Matsubara frequencies used for the Green's functions.
         n_tau : integer, optional
@@ -26,6 +26,10 @@ class Solver(SolverCore):
         n_l : integer, optional
              Number of legendre polynomials to use in accumulations of the Green's functions.
         """
+        if isinstance(gf_struct,dict):
+            print "WARNING: gf_struct should be a list of pairs [ [str,[int,...]], ...], not a dict"
+            gf_struct = [ [k, v] for k, v in gf_struct.iteritems() ]
+
         # Initialise the core solver
         SolverCore.__init__(self, beta=beta, gf_struct=gf_struct, 
                             n_iw=n_iw, n_tau=n_tau, n_l=n_l)
@@ -99,7 +103,7 @@ class Solver(SolverCore):
             fit_known_moments = params_kw.pop("fit_known_moments", None)
 
         print_warning = False
-        for name, indices in self.gf_struct.items():
+        for name, indices in self.gf_struct:
             dim = len(indices)
             if ( (self.G0_iw[name].tail[1]-np.eye(dim)) > 10**(-6) ).any(): print_warning = True
 	if print_warning and mpi.is_master_node():

--- a/python/cthyb/solver_core_desc.py
+++ b/python/cthyb/solver_core_desc.py
@@ -6,10 +6,10 @@ from cpp2py.wrap_generator import *
 module = module_(full_name = "solver_core", doc = "The cthyb solver", app_name = "cthyb")
 
 # Imports
+import pytriqs.atom_diag
 import pytriqs.gf
 import pytriqs.operators
 import pytriqs.statistics.histograms
-import pytriqs.atom_diag
 
 # Add here all includes
 module.add_include("../../cthyb/solver_core.hpp")
@@ -25,6 +25,7 @@ module.add_preamble("""
 #include <cpp2py/converters/vector.hpp>
 #include <triqs/cpp2py_converters/arrays.hpp>
 #include <triqs/cpp2py_converters/gf.hpp>
+#include <triqs/cpp2py_converters/h5.hpp>
 #include <triqs/cpp2py_converters/operators_real_complex.hpp>
 
 using namespace cthyb;
@@ -86,19 +87,20 @@ c.add_member(c_name = "G2_iwll_ph",
              doc = """Two-particle Green\'s function :math:`G^{(2)}(i\\omega,l,l\')` in the ph-channel (one bosonic matsubara and two legendre)""")
 
 c.add_constructor("""(**cthyb::constr_parameters_t)""", doc = """Construct a CTHYB solver\n\n :param p: Set of parameters specific to the CTHYB solver
-+----------------+--------------------+---------+-----------------------------------------------------------------+
-| Parameter Name | Type               | Default | Documentation                                                   |
-+================+====================+=========+=================================================================+
-| beta           | double             |         | Inverse temperature                                             |
-+----------------+--------------------+---------+-----------------------------------------------------------------+
-| gf_struct      | cthyb::gf_struct_t |         | block structure of the gf                                       |
-+----------------+--------------------+---------+-----------------------------------------------------------------+
-| n_iw           | int                | 1025    | Number of Matsubara frequencies for gf<imfreq, matrix_valued>   |
-+----------------+--------------------+---------+-----------------------------------------------------------------+
-| n_tau          | int                | 10001   | Number of tau points for gf<imtime, matrix_valued>              |
-+----------------+--------------------+---------+-----------------------------------------------------------------+
-| n_l            | int                | 50      | Number of Legendre polynomials for gf<legendre, matrix_valued>  |
-+----------------+--------------------+---------+-----------------------------------------------------------------+""")
++----------------+-----------------------------------+---------+-----------------------------------------------------------------+
+| Parameter Name | Type                              | Default | Documentation                                                   |
++================+===================================+=========+=================================================================+
+| beta           | double                            |         | Inverse temperature                                             |
++----------------+-----------------------------------+---------+-----------------------------------------------------------------+
+| gf_struct      | triqs::hilbert_space::gf_struct_t |         | block structure of the gf                                       |
++----------------+-----------------------------------+---------+-----------------------------------------------------------------+
+| n_iw           | int                               | 1025    | Number of Matsubara frequencies for gf<imfreq, matrix_valued>   |
++----------------+-----------------------------------+---------+-----------------------------------------------------------------+
+| n_tau          | int                               | 10001   | Number of tau points for gf<imtime, matrix_valued>              |
++----------------+-----------------------------------+---------+-----------------------------------------------------------------+
+| n_l            | int                               | 50      | Number of Legendre polynomials for gf<legendre, matrix_valued>  |
++----------------+-----------------------------------+---------+-----------------------------------------------------------------+
+""")
 
 c.add_method("""void solve (**cthyb::solve_parameters_t)""",
              doc = """Solve method that performs CTHYB calculation\n\n :param p: Set of parameters for the CTHYB calculation
@@ -178,7 +180,8 @@ c.add_method("""void solve (**cthyb::solve_parameters_t)""",
 | move_global_prob              | double                                         | 0.05                                             | Overall probability of the global moves                                                                                                                                         |
 +-------------------------------+------------------------------------------------+--------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | imag_threshold                | double                                         | 1.e-15                                           | Threshold below which imaginary components of Delta and h_loc are set to zero                                                                                                   |
-+-------------------------------+------------------------------------------------+--------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+""")
++-------------------------------+------------------------------------------------+--------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+""")
 
 c.add_method("""std::string hdf5_scheme ()""",
              is_static = True,
@@ -442,7 +445,7 @@ c.add_member(c_name = "beta",
              doc = """Inverse temperature""")
 
 c.add_member(c_name = "gf_struct",
-             c_type = "cthyb::gf_struct_t",
+             c_type = "triqs::hilbert_space::gf_struct_t",
              initializer = """  """,
              doc = """block structure of the gf""")
 

--- a/test/c++/G2.cpp
+++ b/test/c++/G2.cpp
@@ -31,7 +31,7 @@ using triqs::operators::c;
 using triqs::operators::c_dag;
 using triqs::operators::n;
 using namespace triqs::gfs;
-using indices_type = triqs::operators::indices_t;
+using triqs::hilbert_space::gf_struct_t;
 
 TEST(CtHyb, G2_measurments) {
 

--- a/test/c++/anderson.cpp
+++ b/test/c++/anderson.cpp
@@ -9,7 +9,7 @@ using triqs::operators::c;
 using triqs::operators::c_dag;
 using triqs::operators::n;
 using namespace triqs::gfs;
-using indices_type = triqs::operators::indices_t;
+using triqs::hilbert_space::gf_struct_t;
 
 TEST(CtHyb, Anderson) {
 
@@ -29,11 +29,11 @@ TEST(CtHyb, Anderson) {
   // GF structure
   enum spin { up, down };
 #ifdef BLOCK
-  std::map<std::string, indices_type> gf_struct{{"up", {0}}, {"down", {0}}};
+  gf_struct_t gf_struct{{"up", {0}}, {"down", {0}}};
   auto n_up   = n("up", 0);
   auto n_down = n("down", 0);
 #else
-  std::map<std::string, indices_type> gf_struct{{"tot", {0, 1}}};
+  gf_struct_t gf_struct{{"tot", {0, 1}}};
   auto n_up   = n("tot", 0);
   auto n_down = n("tot", 1);
 #endif

--- a/test/c++/atomic_gf.cpp
+++ b/test/c++/atomic_gf.cpp
@@ -10,7 +10,7 @@ using triqs::operators::c;
 using triqs::operators::c_dag;
 using triqs::operators::n;
 using namespace triqs::gfs;
-using indices_type = triqs::operators::indices_t;
+using triqs::hilbert_space::gf_struct_t;
 
 TEST(CtHyb, AtomicGf) {
 
@@ -30,7 +30,7 @@ TEST(CtHyb, AtomicGf) {
   H += ed0 * (n("up", 0) + n("dn", 0)) + ed1 * (n("up", 1) + n("dn", 1));
   H += V * (c_dag("up", 0) * c("up", 1) + c_dag("up", 1) * c("up", 0) + c_dag("dn", 0) * c("dn", 1) + c_dag("dn", 1) * c("dn", 0));
 
-  std::map<std::string, indices_type> gf_struct{{"up", {0, 1}}, {"dn", {0, 1}}};
+  gf_struct_t gf_struct{{"up", {0, 1}}, {"dn", {0, 1}}};
 
   // Construct CTQMC solver
   solver_core solver(beta, gf_struct, 1025, 2051);

--- a/test/c++/kanamori.cpp
+++ b/test/c++/kanamori.cpp
@@ -9,7 +9,7 @@ using triqs::operators::c;
 using triqs::operators::c_dag;
 using triqs::operators::n;
 using namespace triqs::gfs;
-using indices_type = triqs::operators::indices_t;
+using triqs::hilbert_space::gf_struct_t;
 
 TEST(CtHyb, Kanamori) {
 
@@ -64,11 +64,9 @@ TEST(CtHyb, Kanamori) {
 #endif
 
   // gf structure
-  std::map<std::string, indices_type> gf_struct;
-  for (int o = 0; o < num_orbitals; ++o) {
-    gf_struct["up-" + std::to_string(o)]   = {0};
-    gf_struct["down-" + std::to_string(o)] = {0};
-  }
+  gf_struct_t gf_struct;
+  for (int o = 0; o < num_orbitals; ++o) gf_struct.push_back({"down-" + std::to_string(o),{0}});
+  for (int o = 0; o < num_orbitals; ++o) gf_struct.push_back({"up-" + std::to_string(o),{0}});
 
   // Construct CTQMC solver
   solver_core solver({beta, gf_struct, 1025, 2500});

--- a/test/c++/legendre.cpp
+++ b/test/c++/legendre.cpp
@@ -9,7 +9,7 @@ using triqs::operators::c;
 using triqs::operators::c_dag;
 using triqs::operators::n;
 using namespace triqs::gfs;
-using indices_type = triqs::operators::indices_t;
+using triqs::hilbert_space::gf_struct_t;
 
 TEST(CtHyb, Legendre) {
 
@@ -32,7 +32,7 @@ TEST(CtHyb, Legendre) {
   // quantum numbers
   std::vector<many_body_op_t> qn{n("up", 0), n("down", 0)};
   // gf structure
-  std::map<std::string, indices_type> gf_struct{{"up", {0}}, {"down", {0}}};
+  gf_struct_t gf_struct{{"up", {0}}, {"down", {0}}};
 
   // Construct CTQMC solver
   solver_core solver({beta, gf_struct, 1025, 2500, 50});
@@ -60,8 +60,8 @@ TEST(CtHyb, Legendre) {
   // Solve!
   solver.solve(p);
 
-  auto & G_l = *solver.G_l;
-  
+  auto &G_l = *solver.G_l;
+
   // Save the results
   if (rank == 0) {
     triqs::h5::file G_file("legendre.out.h5", 'w');

--- a/test/c++/spinless.cpp
+++ b/test/c++/spinless.cpp
@@ -9,7 +9,7 @@ using triqs::operators::c;
 using triqs::operators::c_dag;
 using triqs::operators::n;
 using namespace triqs::gfs;
-using indices_type = triqs::operators::indices_t;
+using triqs::hilbert_space::gf_struct_t;
 
 TEST(CtHyb, Spinless) {
 
@@ -27,7 +27,7 @@ TEST(CtHyb, Spinless) {
 
   // define operators
   auto H = U * n("tot", 0) * n("tot", 1) - t * c_dag("tot", 0) * c("tot", 1) - t * c_dag("tot", 1) * c("tot", 0);
-  std::map<std::string, indices_type> gf_struct{{"tot", {0, 1}}};
+  gf_struct_t gf_struct{{"tot", {0, 1}}};
 
 #ifdef QN
   // quantum numbers

--- a/test/python/h5_read_write.py
+++ b/test/python/h5_read_write.py
@@ -7,7 +7,7 @@ from cthyb import SolverCore
 
 cp = dict(
     beta=10.0,
-    gf_struct={'up' : [0], 'do' : [0]},
+    gf_struct=[['up',[0]], ['do',[0]]],
     n_iw=1025, n_tau=2500, n_l=20
     )
 

--- a/test/python/histograms.py
+++ b/test/python/histograms.py
@@ -10,7 +10,7 @@ import numpy as np
 
 spin_names = ("up","dn")
 mkind = lambda sn: (sn,0)
-gf_struct = {"up":[0], "dn":[0]}
+gf_struct = [["dn",[0]], ["up",[0]]]
 
 # Input parameters
 beta = 10.0

--- a/test/python/measure_static.py
+++ b/test/python/measure_static.py
@@ -35,7 +35,7 @@ H = U*n("up",1)*n("dn",1) + U*n("up",2)*n("dn",2)
 H = H + 0.5*h*(n("up",1) - n("dn",1)) + 0.5*h*(n("up",2) - n("dn",2))
 
 # Construct the solver
-S = Solver(beta=beta, gf_struct={"up":[1,2], "dn":[1,2]}, n_tau=n_tau, n_iw=n_iw)
+S = Solver(beta=beta, gf_struct=[["dn",[1,2]], ["up",[1,2]]], n_tau=n_tau, n_iw=n_iw)
 
 # Set hybridization function
 delta_w = GfImFreq(indices = [1,2], beta=beta)

--- a/test/python/move_global.py
+++ b/test/python/move_global.py
@@ -26,6 +26,7 @@ V = 2.0 * np.eye(num_orbitals) + 0.2 * (np.ones(num_orbitals) - np.eye(num_orbit
 spin_names = ('up','dn')
 orb_names = range(num_orbitals)
 gf_struct = set_operator_structure(spin_names,orb_names,True)
+gf_struct.reverse() # the reference data was computed with reversed block order
 
 # Construct solver
 S = Solver(beta=beta, gf_struct=gf_struct, n_iw=1025, n_tau=2500, n_l=50)

--- a/test/python/single_site_bethe.py
+++ b/test/python/single_site_bethe.py
@@ -14,7 +14,7 @@ U = 2.5
 mu = (U/2.0)+0.2
 beta = 100.0
 
-gf_struct = {'up':[0],'down':[0]}
+gf_struct = [['down',[0]], ['up',[0]]]
 
 # Construct solver
 S = Solver(beta=beta, gf_struct=gf_struct, n_iw=1025, n_tau=3000, n_l=30)


### PR DESCRIPTION
Fixes in accordance with https://github.com/TRIQS/triqs/pull/559

To be tested against pull request above (i.e. CI will fail).
Tested locally with all tests passing

- c++ gf_struct_t becomes `vector<pair<string, vector<variant<int, string>>>>`
- python gf_struct becomes list of pairs `[['up',[0]], ...]`
- Adjusting tests accordingly
- Adjust docs accordingly
- Updating move_global test ref data after checking
  (Changed block order in h5)