### PR TITLE
[h5] Store additional member variables when storing solver object

### DIFF
--- a/c++/triqs_cthyb/container_set.cpp
+++ b/c++/triqs_cthyb/container_set.cpp
@@ -52,7 +52,7 @@ namespace triqs_cthyb {
     h5_read(grp, "G_tau", c.G_tau);
     h5_read(grp, "G_tau_accum", c.G_tau_accum);
     h5_read(grp, "G_l", c.G_l);
-    if( grp.has_key("O_tau") ) h5_read(grp, "O_tau", c.O_tau);
+    h5_try_read(grp, "O_tau", c.O_tau);
 
     h5_read(grp, "G2_tau", c.G2_tau);
     h5_read(grp, "G2_iw", c.G2_iw);

--- a/c++/triqs_cthyb/solver_core.hpp
+++ b/c++/triqs_cthyb/solver_core.hpp
@@ -147,13 +147,20 @@ namespace triqs_cthyb {
     friend void h5_write(triqs::h5::group h5group, std::string subgroup_name, solver_core const &s) {
       triqs::h5::group grp = subgroup_name.empty() ? h5group : h5group.create_group(subgroup_name);
       h5_write_attribute(grp, "TRIQS_HDF5_data_scheme", solver_core::hdf5_scheme());
-      //h5_write_attribute(grp, "TRIQS_GIT_HASH", std::string(STRINGIZE(TRIQS_GIT_HASH)));
-      //h5_write_attribute(grp, "CTHYB_GIT_HASH", std::string(STRINGIZE(CTHYB_GIT_HASH)));
+      h5_write_attribute(grp, "TRIQS_GIT_HASH", std::string(STRINGIZE(TRIQS_GIT_HASH)));
+      h5_write_attribute(grp, "CTHYB_GIT_HASH", std::string(STRINGIZE(CTHYB_GIT_HASH)));
       h5_write(grp, "container_set", s.container_set());
       h5_write(grp, "constr_parameters", s.constr_parameters);
       h5_write(grp, "solve_parameters", s.solve_parameters);
       h5_write(grp, "G0_iw", s._G0_iw);
       h5_write(grp, "Delta_tau", s._Delta_tau);
+
+      h5_write(grp, "h_diag", s.h_diag);
+      h5_write(grp, "h_loc", s._h_loc);
+      h5_write(grp, "density_matrix", s._density_matrix);
+      h5_write(grp, "average_sign", s._average_sign);
+      h5_write(grp, "solve_status", s._solve_status);
+      h5_write(grp, "Delta_infty_vec", s.Delta_infty_vec);
     }
 
     // Function that read all containers to hdf5 file
@@ -166,6 +173,14 @@ namespace triqs_cthyb {
       h5_read(grp, "solve_parameters", s.solve_parameters);
       h5_read(grp, "G0_iw", s._G0_iw);
       h5_read(grp, "Delta_tau", s._Delta_tau);
+
+      h5_try_read(grp, "h_diag", s.h_diag);
+      h5_try_read(grp, "h_loc", s._h_loc);
+      h5_try_read(grp, "density_matrix", s._density_matrix);
+      h5_try_read(grp, "average_sign", s._average_sign);
+      h5_try_read(grp, "solve_status", s._solve_status);
+      h5_try_read(grp, "Delta_infty_vec", s.Delta_infty_vec);
+
       return s;
     }
   };

--- a/test/python/h5_read_write.py
+++ b/test/python/h5_read_write.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytriqs.utility.mpi as mpi
-from pytriqs.gf import GfImFreq, SemiCircular, inverse, iOmega_n
+from pytriqs.gf import GfImFreq, BlockGf, SemiCircular, inverse, iOmega_n
 from pytriqs.operators import n, c, c_dag
 from pytriqs.archive import HDFArchive
 from triqs_cthyb import SolverCore
@@ -52,8 +52,10 @@ for key in dir(solver_ref):
         val = getattr(solver, key)
         val_ref = getattr(solver_ref, key)
 
-        if val is None:
-            assert( val == val_ref )
-        else:
+        if isinstance(val, BlockGf):
             for (n1, g1), (n1, g2) in zip(val, val_ref):
                 np.testing.assert_array_almost_equal(g1.data, g2.data)
+        elif val == None or isinstance(val, list):
+            assert(val == val_ref)
+        else:
+            raise Exception("Invalid type in comparison")

--- a/test/python/h5_read_write_more.py
+++ b/test/python/h5_read_write_more.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
 
 
         cf_attr = [
-            'Delta_infty', 'Delta_tau', 'G0_iw', 'G2_iw', 'G2_iw_nfft', 'G2_iw_ph', 'G2_iw_ph_nfft', 'G2_iw_pp', 'G2_iw_pp_nfft', 'G2_iwll_ph', 'G2_iwll_pp', 'G2_static_ll', 'G2_static_tau', 'G2_tau', 'G_l', 'G_tau', 'G_tau_accum', 'O_tau', 'average_sign', 'constr_parameters', 'density_matrix', 'h_loc', 'last_constr_parameters', 'last_solve_parameters', 'performance_analysis', 'solve_parameters'
+            'Delta_infty', 'Delta_tau', 'G0_iw', 'G2_iw', 'G2_iw_nfft', 'G2_iw_ph', 'G2_iw_ph_nfft', 'G2_iw_pp', 'G2_iw_pp_nfft', 'G2_iwll_ph', 'G2_iwll_pp', 'G2_tau', 'G_l', 'G_tau', 'G_tau_accum', 'O_tau', 'average_sign', 'constr_parameters', 'density_matrix', 'h_loc', 'last_constr_parameters', 'last_solve_parameters', 'performance_analysis', 'solve_parameters'
             ]
 
         success = True


### PR DESCRIPTION
-Store additionally the following members together with the solver object
 h_diag, _h_loc, _density_matrix, _average_sign, _solve_status, Delta_infty_vec
-TODO: move the histogram members pert_order, pert_order_total
 and performance_analysis into the container_set class as std::optional
 and add them to the corresponding h5_read/h5_write

This PR fixes Issue #115 