### PR TITLE
extend h5 write test to compare h_loc and perturbation_order

### DIFF
--- a/test/python/h5_read_write.py
+++ b/test/python/h5_read_write.py
@@ -41,8 +41,11 @@ with HDFArchive(filename, 'r') as A:
     solver_ref = A['solver']
 
 assert( solver.last_constr_parameters == solver_ref.last_constr_parameters )
-assert( solver.last_solve_parameters == solver.last_solve_parameters )
+assert( solver.last_solve_parameters == solver_ref.last_solve_parameters )
 #assert( solver.last_container_set == solver_ref.last_container_set ) # want to write this
+assert( solver.perturbation_order == solver_ref.perturbation_order )
+assert( solver.h_loc == solver_ref.h_loc )
+
 
 # -- Poor mans version of comparison of the container sets
 for key in dir(solver_ref):

--- a/test/python/h5_read_write.py
+++ b/test/python/h5_read_write.py
@@ -4,6 +4,7 @@ from pytriqs.gf import GfImFreq, BlockGf, SemiCircular, inverse, iOmega_n
 from pytriqs.operators import n, c, c_dag
 from pytriqs.archive import HDFArchive
 from triqs_cthyb import SolverCore
+from pytriqs.statistics.histograms import Histogram
 
 cp = dict(
     beta=10.0,
@@ -28,6 +29,7 @@ sp = dict(
     n_warmup_cycles = 50,
     n_cycles = 500,
     move_double = False,
+    measure_pert_order = True
     )
     
 solver.solve(**sp)


### PR DESCRIPTION
I've experienced the problem that when I save and load a CTHYB solver to an h5 file using python, I always get that `solver.h_loc` is 0 and `solver.perturbation_order` is empty. I added these checks to the h5 test

I also fixed comparison of last_solve_parameters