### PR TITLE
Fix for issue #130

### DIFF
--- a/c++/triqs_cthyb/impurity_trace.cpp
+++ b/c++/triqs_cthyb/impurity_trace.cpp
@@ -294,13 +294,17 @@ namespace triqs_cthyb {
 
       // Check that the final block is the same as the initial block or -1, indicating structural cancellation
       // This guarantees that the density matrix is blockwise diagonal (otherwise the code will have thrown an error).
-      if (measure_density_matrix) {
-        if ((block_lnorm_pair.first != b) && (block_lnorm_pair.first != -1))
-          std::cerr << "WARNING: The product of atomic operators has a matrix element in the off-diagonal block (" << b << ","
-                    << block_lnorm_pair.first << ")\n"
-                    << "You will not be able to use this density matrix to calculate expectations values of operators that do not "
-                       "commute with the local Hamiltonian!"
+      if (measure_density_matrix) { 
+          static bool first_warning_issued = false;
+        if ( (not first_warning_issued) and (block_lnorm_pair.first != b) && (block_lnorm_pair.first != -1)) { 
+            first_warning_issued = true;
+            mpi::communicator world;
+            if (world.rank()== 0)
+            std::cerr << "\nWARNING: The product of atomic operators has a matrix element in the off-diagonal blocks!!! \n"
+                    << "You will not be able to use the measured density matrix to calculate expectations values\n" 
+                    "of operators that do not commute with the local Hamiltonian!\n"
                     << std::endl;
+      }
       }
 
       if (block_lnorm_pair.first == b) { // final structural check B ---> returns to B.

--- a/c++/triqs_cthyb/impurity_trace.cpp
+++ b/c++/triqs_cthyb/impurity_trace.cpp
@@ -294,17 +294,17 @@ namespace triqs_cthyb {
 
       // Check that the final block is the same as the initial block or -1, indicating structural cancellation
       // This guarantees that the density matrix is blockwise diagonal (otherwise the code will have thrown an error).
-      if (measure_density_matrix) { 
-          static bool first_warning_issued = false;
-        if ( (not first_warning_issued) and (block_lnorm_pair.first != b) && (block_lnorm_pair.first != -1)) { 
-            first_warning_issued = true;
-            mpi::communicator world;
-            if (world.rank()== 0)
+      if (measure_density_matrix) {
+        static bool first_warning_issued = false;
+        if ((not first_warning_issued) and (block_lnorm_pair.first != b) && (block_lnorm_pair.first != -1)) {
+          first_warning_issued = true;
+          mpi::communicator world;
+          if (world.rank() == 0)
             std::cerr << "\nWARNING: The product of atomic operators has a matrix element in the off-diagonal blocks!!! \n"
-                    << "You will not be able to use the measured density matrix to calculate expectations values\n" 
-                    "of operators that do not commute with the local Hamiltonian!\n"
-                    << std::endl;
-      }
+                      << "You will not be able to use the measured density matrix to calculate expectations values\n"
+                         "of operators that do not commute with the local Hamiltonian!\n"
+                      << std::endl;
+        }
       }
 
       if (block_lnorm_pair.first == b) { // final structural check B ---> returns to B.


### PR DESCRIPTION
This fixes issue https://github.com/TRIQS/cthyb/issues/130 , where a large warning output is generated when `measure_density_matrix=True`. This fix includes: 
* error output for off-diag elements is only printed once and for each
  block and each call of calc trace
* error output appears only on master rank of mpi
* adapted error message

This fix should also be applied as a bugfix to 2.2.x.