### PR TITLE
force G_iw to be hermitian and give a warning if it's not

### DIFF
--- a/python/triqs_cthyb/solver.py
+++ b/python/triqs_cthyb/solver.py
@@ -152,11 +152,11 @@ class Solver(SolverCore):
                 known_moments[1,...] = np.eye(bl_size)
                 self.G_iw[bl].set_from_fourier(g, known_moments)
 
+            self.G_iw_raw = self.G_iw.copy()
             if not is_gf_hermitian(self.G_iw):
                 mpi.report('WARNING: G_iw is not Hermitian. Forcing G_iw to be Hermitian')
             for name, g in self.G_iw:
                 self.G_iw[name] = make_hermitian(g)
-            self.G_iw_raw = self.G_iw.copy()
 
             if self.Delta_interface:
                 G0_iw = self.G_iw.copy()

--- a/python/triqs_cthyb/solver.py
+++ b/python/triqs_cthyb/solver.py
@@ -152,7 +152,10 @@ class Solver(SolverCore):
                 known_moments[1,...] = np.eye(bl_size)
                 self.G_iw[bl].set_from_fourier(g, known_moments)
 
-            assert is_gf_hermitian(self.G_iw)
+            if not is_gf_hermitian(self.G_iw):
+                mpi.report('WARNING: G_iw is not Hermitian. Forcing G_iw to be Hermitian')
+            for name, g in self.G_iw:
+                self.G_iw[name] = make_hermitian(g)
             self.G_iw_raw = self.G_iw.copy()
 
             if self.Delta_interface:


### PR DESCRIPTION
Currently in the tail fit procedure it first asserts that the gf is hermitian. 

Instead of doing this, I think it makes more sense to make the gf hermitian and give a warning if it wasn't in the first place. This is more consistent with what is done with G0_iw at the beginning of Solver_core.cpp

Even in cases where is_gf_hermitian gives True, I think it's a good idea to force it to be completely Hermitian since if it's slightly non-hermitian on one iteration that can cause it to be more non-hermitian on the next. 