### PR TITLE
High frequency moments for self-energy tail fitting

### DIFF
--- a/python/triqs_cthyb/solver.py
+++ b/python/triqs_cthyb/solver.py
@@ -161,8 +161,7 @@ class Solver(SolverCore):
                                                  self.last_solve_parameters['h_int']
                                                  )
 
-                self.Sigma_Hartree = self.Sigma_moments[0]
-                
+                self.Sigma_Hartree = {bl: sigma_bl[0] for bl, sigma_bl in self.Sigma_moments.items()}
 
             # Fourier transform G_tau to obtain G_iw
             for bl, g in self.G_tau:
@@ -189,13 +188,8 @@ class Solver(SolverCore):
 
             if perform_tail_fit:
 
-                if self.last_solve_parameters["measure_density_matrix"]:
-                    fit_known_moments ={}
-                    for name, sig in self.Sigma_iw:
-                        shape = [2]+list(sig.target_shape)
-                        fit_known_moments[name] = np.zeros(shape, dtype=complex)
-                        fit_known_moments[name][0] = self.Sigma_moments[0][name]
-                        fit_known_moments[name][1] = self.Sigma_moments[1][name]
+                if fit_known_moments is None and self.last_solve_parameters["measure_density_matrix"]:
+                    fit_known_moments = self.Sigma_moments
 
                 cthyb_tail_fit(
                     Sigma_iw=self.Sigma_iw,

--- a/python/triqs_cthyb/tail_fit.py
+++ b/python/triqs_cthyb/tail_fit.py
@@ -24,6 +24,90 @@ import numpy as np
 
 from triqs.gf.gf_fnt import fit_hermitian_tail_on_window, replace_by_tail
 
+from triqs.operators import c, c_dag
+from triqs.atom_diag import trace_rho_op
+
+
+def sigma_high_frequency_moments(density_matrix,
+                           h_loc, 
+                           gf_struct, 
+                           h_int):
+    """
+    Calculate the first and second analytic high frequency moments of Sigma_iw
+    following Rev. Mod. Phys. 83, 349 (2011), where the first and second moments are
+    (1) Sigma_Hartree = -<{[H,c],c+}>
+    (2) Sigma_1       = <{[H,[H,c]],c+}> - Sigma_Hartree^2,
+    where H is th interaction Hamiltonian
+
+    Parameters
+    ----------
+    density_matrix : list, np.ndarray
+                     measured density matrix from TRIQS/CTHYB.
+    h_loc          : h_loc_diagonalization
+                     h_loc_diagonalizatoin from TRIQS/CTHYB.
+    gf_struct      : gf_struct_t
+                     Block structure of Green's function.
+    h_int          : H_int
+                     interaction Hamiltonian
+
+    Returns
+    -------
+    moments        : list
+                     first and second moments in a list with the
+                     same structure as the Green's function
+    """
+    def comm(A,B): return A*B - B*A
+    def anticomm(A,B): return A*B + B*A
+
+    # Sigma_HF term
+    sigma_hf = {bl : np.zeros((bl_size, bl_size),dtype=complex) for bl, bl_size in gf_struct}
+    for bl, bl_size in gf_struct:
+        for orb1 in range(bl_size):
+            for orb2 in range(bl_size):
+                op = -anticomm(comm(h_int, c(bl,orb1)), c_dag(bl,orb2))
+                for term, coef in op:
+                    bl1, u1 = term[0][1]
+                    bl2, u2 = term[1][1]
+
+                    sigma_hf[bl][orb1,orb2] += coef*trace_rho_op(density_matrix,
+                                                                 c_dag(bl1,u1)*c(bl2,u2),
+                                                                 h_loc
+                                                                 )
+    # Sigma_1/iwn term
+    sigma_1 = {bl : np.zeros((bl_size,bl_size),dtype=complex) for bl,bl_size in gf_struct}
+    for bl, bl_size in gf_struct:
+        for orb1 in range(bl_size):
+            for orb2 in range(bl_size):
+                op = anticomm(comm(h_int, comm(h_int, c(bl,orb1))), c_dag(bl,orb2))
+                for term, coef in op:
+
+                    if len(term) == 2:
+
+                        bl1, u1 = term[0][1]
+                        bl2, u2 = term[1][1]
+
+                        sigma_1[bl][orb1,orb2] += coef*trace_rho_op(density_matrix,
+                                                                    c_dag(bl1,u1)*c(bl2,u2),
+                                                                    h_loc
+                                                                    )
+                    elif len(term) == 4:
+
+                        bl1, u1 = term[0][1]
+                        bl2, u2 = term[1][1]
+                        bl3, u3 = term[2][1]
+                        bl4, u4 = term[3][1]
+
+                        sigma_1[bl][orb1,orb2] += coef*trace_rho_op(density_matrix,
+                                                                    c_dag(bl1,u1)*c_dag(bl2,u2)*c(bl3,u3)*c(bl4,u4),
+                                                                    h_loc
+                                                                    )
+
+                sigma_1[bl][orb1,orb2] -= sigma_hf[bl][orb1,orb2]**2
+
+    return [sigma_hf, sigma_1]
+
+
+
 def tail_fit(
         Sigma_iw,
         fit_min_n=None, fit_max_n=None,

--- a/python/triqs_cthyb/util.py
+++ b/python/triqs_cthyb/util.py
@@ -24,6 +24,10 @@ CTHYB utility functions:
 from math import ceil
 from numpy import argmax
 
+import numpy as np
+from triqs.operators import c, c_dag
+from triqs.atom_diag import trace_rho_op
+
 def block_size_from_gf_struct(block_name, gf_struct):
     bns, idxs = list(zip(*gf_struct))
     bidx = bns.index(block_name)
@@ -41,4 +45,16 @@ def estimate_nfft_buf_size(gf_struct, pert_order_histograms):
             buf_sizes[bn] = int(max(ceil((max_order * max_order) / (block_size * block_size)), 1))
 
     return buf_sizes
+
+def orbital_occupations(density_matrix, gf_struct, h_loc_diag):
+    
+    dtype=density_matrix[0].dtype
+    occ_mat = {bl: np.zeros((bl_size,bl_size), dtype=dtype) for bl, bl_size in gf_struct}
+
+    for bl, bl_size in gf_struct:
+        for i in range(bl_size):
+            for j in range(bl_size):
+                occ_mat[bl][i,j] = trace_rho_op(density_matrix, c_dag(bl, i)*c(bl,j), h_loc_diag)
+
+    return occ_mat
 

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -5,7 +5,7 @@ foreach(file ${all_h5_ref_files})
 endforeach()
 
 # List of all tests
-set(all_tests setup_Delta_tau_and_h_loc single_site_bethe atomic_observables kanamori_py slater measure_static histograms move_global h5_read_write h5_read_write_more O_tau_ins)
+set(all_tests setup_Delta_tau_and_h_loc single_site_bethe atomic_observables kanamori_py slater measure_static histograms move_global h5_read_write h5_read_write_more O_tau_ins high_freq_tail)
 if(Local_hamiltonian_is_complex)
   list(APPEND all_tests atomic_gf_complex atomdiag_ed complex_bug81)
   if(Hybridisation_is_complex)

--- a/test/python/high_freq_tail.py
+++ b/test/python/high_freq_tail.py
@@ -11,9 +11,9 @@ import triqs.utility.mpi as mpi
 D,V,U = 1., 0.2, 4.
 ef,beta = -U/2., 50
 
-H = U*n('up_0',0)*n('down_0',0)
+H = U*n('up',0)*n('down',0)
 
-S = Solver(beta=beta, gf_struct=[('up_0',1), ('down_0',1)])
+S = Solver(beta=beta, gf_struct=[('up',1), ('down',1)])
 
 for name, g0 in S.G0_iw: g0 << inverse(iOmega_n - ef - V**2 * Wilson(D))
 
@@ -31,21 +31,21 @@ S.solve(h_int = H,
         )
 
 # exact moments
-n_up = trace_rho_op(S.density_matrix, n('up_0',0), S.h_loc_diagonalization)
-n_dn = trace_rho_op(S.density_matrix, n('down_0',0), S.h_loc_diagonalization)
+n_up = trace_rho_op(S.density_matrix, n('up',0), S.h_loc_diagonalization)
+n_dn = trace_rho_op(S.density_matrix, n('down',0), S.h_loc_diagonalization)
 
-np.testing.assert_almost_equal(S.Sigma_Hartree['up_0'][0,0], U*n_dn)
-np.testing.assert_almost_equal(S.Sigma_Hartree['down_0'][0,0], U*n_up)
+np.testing.assert_almost_equal(S.Sigma_Hartree['up'][0,0], U*n_dn)
+np.testing.assert_almost_equal(S.Sigma_Hartree['down'][0,0], U*n_up)
 
-np.testing.assert_almost_equal(S.Sigma_moments[0]['up_0'][0,0], U*n_dn)
-np.testing.assert_almost_equal(S.Sigma_moments[0]['down_0'][0,0], U*n_up)
+np.testing.assert_almost_equal(S.Sigma_moments['up'][0,0,0], U*n_dn)
+np.testing.assert_almost_equal(S.Sigma_moments['down'][0,0,0], U*n_up)
 
-np.testing.assert_almost_equal(S.Sigma_moments[1]['up_0'][0,0], U*U*n_dn*(1-n_dn))
-np.testing.assert_almost_equal(S.Sigma_moments[1]['down_0'][0,0], U*U*n_up*(1-n_up))
+np.testing.assert_almost_equal(S.Sigma_moments['up'][1,0,0], U*U*n_dn*(1-n_dn))
+np.testing.assert_almost_equal(S.Sigma_moments['down'][1,0,0], U*U*n_up*(1-n_up))
 
 
 # magnetic case
-S = Solver(beta=beta, gf_struct=[('up_0',1), ('down_0',1)])
+S = Solver(beta=beta, gf_struct=[('up',1), ('down',1)])
 
 for name, g0 in S.G0_iw: 
     if 'up' in name:
@@ -62,14 +62,14 @@ S.solve(h_int = H,
         )
 
 # exact moments
-n_up = trace_rho_op(S.density_matrix, n('up_0',0), S.h_loc_diagonalization)
-n_dn = trace_rho_op(S.density_matrix, n('down_0',0), S.h_loc_diagonalization)
+n_up = trace_rho_op(S.density_matrix, n('up',0), S.h_loc_diagonalization)
+n_dn = trace_rho_op(S.density_matrix, n('down',0), S.h_loc_diagonalization)
 
-np.testing.assert_almost_equal(S.Sigma_Hartree['up_0'][0,0], U*n_dn)
-np.testing.assert_almost_equal(S.Sigma_Hartree['down_0'][0,0], U*n_up)
+np.testing.assert_almost_equal(S.Sigma_Hartree['up'][0,0], U*n_dn)
+np.testing.assert_almost_equal(S.Sigma_Hartree['down'][0,0], U*n_up)
 
-np.testing.assert_almost_equal(S.Sigma_moments[0]['up_0'][0,0], U*n_dn)
-np.testing.assert_almost_equal(S.Sigma_moments[0]['down_0'][0,0], U*n_up)
+np.testing.assert_almost_equal(S.Sigma_moments['up'][0,0,0], U*n_dn)
+np.testing.assert_almost_equal(S.Sigma_moments['down'][0,0,0], U*n_up)
 
-np.testing.assert_almost_equal(S.Sigma_moments[1]['up_0'][0,0], U*U*n_dn*(1-n_dn))
-np.testing.assert_almost_equal(S.Sigma_moments[1]['down_0'][0,0], U*U*n_up*(1-n_up))
+np.testing.assert_almost_equal(S.Sigma_moments['up'][1,0,0], U*U*n_dn*(1-n_dn))
+np.testing.assert_almost_equal(S.Sigma_moments['down'][1,0,0], U*U*n_up*(1-n_up))

--- a/test/python/high_freq_tail.py
+++ b/test/python/high_freq_tail.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+from triqs.gf import Gf, BlockGf, iOmega_n, inverse, Fourier, Wilson
+from triqs_cthyb import Solver
+from triqs.atom_diag import trace_rho_op
+from triqs.operators import n, c, c_dag
+import triqs.utility.mpi as mpi
+
+# paramagnetic one-orbital case
+
+D,V,U = 1., 0.2, 4.
+ef,beta = -U/2., 50
+
+H = U*n('up_0',0)*n('down_0',0)
+
+S = Solver(beta=beta, gf_struct=[('up_0',1), ('down_0',1)])
+
+for name, g0 in S.G0_iw: g0 << inverse(iOmega_n - ef - V**2 * Wilson(D))
+
+
+S.solve(h_int = H,
+        n_cycles = 100000,
+        length_cycle = 200,
+        n_warmup_cycles = 10000,
+        measure_density_matrix=True,
+        use_norm_as_weight =True,
+        perform_tail_fit=True,
+        fit_max_moment = 4,
+        fit_min_w = 5,
+        fit_max_w = 9
+        )
+
+# exact moments
+n_up = trace_rho_op(S.density_matrix, n('up_0',0), S.h_loc_diagonalization)
+n_dn = trace_rho_op(S.density_matrix, n('down_0',0), S.h_loc_diagonalization)
+
+np.testing.assert_almost_equal(S.Sigma_Hartree['up_0'][0,0], U*n_dn)
+np.testing.assert_almost_equal(S.Sigma_Hartree['down_0'][0,0], U*n_up)
+
+np.testing.assert_almost_equal(S.Sigma_moments[0]['up_0'][0,0], U*n_dn)
+np.testing.assert_almost_equal(S.Sigma_moments[0]['down_0'][0,0], U*n_up)
+
+np.testing.assert_almost_equal(S.Sigma_moments[1]['up_0'][0,0], U*U*n_dn*(1-n_dn))
+np.testing.assert_almost_equal(S.Sigma_moments[1]['down_0'][0,0], U*U*n_up*(1-n_up))
+
+
+# magnetic case
+S = Solver(beta=beta, gf_struct=[('up_0',1), ('down_0',1)])
+
+for name, g0 in S.G0_iw: 
+    if 'up' in name:
+        g0 << inverse(iOmega_n - ef+1 - V**2 * Wilson(D))
+    else:
+        g0 << inverse(iOmega_n - ef-1 - V**2 * Wilson(D))
+
+S.solve(h_int = H,
+        n_cycles = 100000,
+        length_cycle = 200,
+        n_warmup_cycles = 10000,
+        measure_density_matrix=True,
+        use_norm_as_weight =True
+        )
+
+# exact moments
+n_up = trace_rho_op(S.density_matrix, n('up_0',0), S.h_loc_diagonalization)
+n_dn = trace_rho_op(S.density_matrix, n('down_0',0), S.h_loc_diagonalization)
+
+np.testing.assert_almost_equal(S.Sigma_Hartree['up_0'][0,0], U*n_dn)
+np.testing.assert_almost_equal(S.Sigma_Hartree['down_0'][0,0], U*n_up)
+
+np.testing.assert_almost_equal(S.Sigma_moments[0]['up_0'][0,0], U*n_dn)
+np.testing.assert_almost_equal(S.Sigma_moments[0]['down_0'][0,0], U*n_up)
+
+np.testing.assert_almost_equal(S.Sigma_moments[1]['up_0'][0,0], U*U*n_dn*(1-n_dn))
+np.testing.assert_almost_equal(S.Sigma_moments[1]['down_0'][0,0], U*U*n_up*(1-n_up))

--- a/test/python/high_freq_tail.py
+++ b/test/python/high_freq_tail.py
@@ -6,11 +6,10 @@ from triqs.atom_diag import trace_rho_op
 from triqs.operators import n, c, c_dag
 import triqs.utility.mpi as mpi
 
-# paramagnetic one-orbital case
-
 D,V,U = 1., 0.2, 4.
 ef,beta = -U/2., 50
 
+# paramagnetic one-orbital case
 H = U*n('up',0)*n('down',0)
 
 S = Solver(beta=beta, gf_struct=[('up',1), ('down',1)])
@@ -30,21 +29,21 @@ S.solve(h_int = H,
         fit_max_w = 9
         )
 
+# Sigma_Hartree = G1 - E
+E = {term[0][1][0] : coef for term, coef in S.h_loc0}
+for spin in ['up','down']: np.testing.assert_almost_equal(S.Sigma_moments[spin][0,0,0], S.G_moments[spin][2,0,0]-E[spin])
+
 # exact moments
 n_up = trace_rho_op(S.density_matrix, n('up',0), S.h_loc_diagonalization)
 n_dn = trace_rho_op(S.density_matrix, n('down',0), S.h_loc_diagonalization)
 
-np.testing.assert_almost_equal(S.Sigma_Hartree['up'][0,0], U*n_dn)
-np.testing.assert_almost_equal(S.Sigma_Hartree['down'][0,0], U*n_up)
-
-np.testing.assert_almost_equal(S.Sigma_moments['up'][0,0,0], U*n_dn)
-np.testing.assert_almost_equal(S.Sigma_moments['down'][0,0,0], U*n_up)
-
-np.testing.assert_almost_equal(S.Sigma_moments['up'][1,0,0], U*U*n_dn*(1-n_dn))
-np.testing.assert_almost_equal(S.Sigma_moments['down'][1,0,0], U*U*n_up*(1-n_up))
+for spin, nimp in zip(['up', 'down'], [n_dn, n_up]):
+    np.testing.assert_almost_equal(S.Sigma_Hartree[spin][0,0], U*nimp)
+    np.testing.assert_almost_equal(S.Sigma_moments[spin][0,0,0], U*nimp)
+    np.testing.assert_almost_equal(S.Sigma_moments[spin][1,0,0], U*U*nimp*(1-nimp))
 
 
-# magnetic case
+# magnetic one-orbital case
 S = Solver(beta=beta, gf_struct=[('up',1), ('down',1)])
 
 for name, g0 in S.G0_iw: 
@@ -61,15 +60,15 @@ S.solve(h_int = H,
         use_norm_as_weight =True
         )
 
+# Sigma_Hartree = G1 - E
+E = {term[0][1][0] : coef for term, coef in S.h_loc0}
+for spin in ['up','down']: np.testing.assert_almost_equal(S.Sigma_moments[spin][0,0,0], S.G_moments[spin][2,0,0]-E[spin])
+
 # exact moments
 n_up = trace_rho_op(S.density_matrix, n('up',0), S.h_loc_diagonalization)
 n_dn = trace_rho_op(S.density_matrix, n('down',0), S.h_loc_diagonalization)
 
-np.testing.assert_almost_equal(S.Sigma_Hartree['up'][0,0], U*n_dn)
-np.testing.assert_almost_equal(S.Sigma_Hartree['down'][0,0], U*n_up)
-
-np.testing.assert_almost_equal(S.Sigma_moments['up'][0,0,0], U*n_dn)
-np.testing.assert_almost_equal(S.Sigma_moments['down'][0,0,0], U*n_up)
-
-np.testing.assert_almost_equal(S.Sigma_moments['up'][1,0,0], U*U*n_dn*(1-n_dn))
-np.testing.assert_almost_equal(S.Sigma_moments['down'][1,0,0], U*U*n_up*(1-n_up))
+for spin, nimp in zip(['up', 'down'], [n_dn, n_up]):
+    np.testing.assert_almost_equal(S.Sigma_Hartree[spin][0,0], U*nimp)
+    np.testing.assert_almost_equal(S.Sigma_moments[spin][0,0,0], U*nimp)
+    np.testing.assert_almost_equal(S.Sigma_moments[spin][1,0,0], U*U*nimp*(1-nimp))


### PR DESCRIPTION
The calculation of the high-frequency asymptotic expansion of the self-energy is implemented. This feature is now automatically used when the user measures the density matrix (``measure_density_matrix=True``) in CT-HYB. The moments are stored as a member of the Solver class called ``Sigma_moments``, which is a list of dictionary objects that have the same structure as the block green's function.