### PR TITLE
[fix] enforce hermiticity of moments

### DIFF
--- a/python/triqs_cthyb/tail_fit.py
+++ b/python/triqs_cthyb/tail_fit.py
@@ -78,10 +78,7 @@ def sigma_high_frequency_moments(density_matrix,
                 sigma_moments[bl][1,orb1,orb2] = trace_rho_op(density_matrix, op_iw, ad_imp) - sigma_moments[bl][0,orb1,orb2]**2
         # enforce hermiticity
         for idx in [0, 1]:
-            moments_non_herm = sigma_moments[bl][idx, :, :].copy()
             sigma_moments[bl][idx, :, :] = 0.5*(sigma_moments[bl][idx, :, :] + sigma_moments[bl][idx, :, :].T.conj())
-        if np.linalg.norm(sigma_moments[bl][idx, :, :] - moments_non_herm) > 1e-3:
-            mpi.report('\nWARNING: Hermiticity of Sigma moments is enforced, but violation was larger than 1e-3. Probably due to poor statistics.\n')
 
     return sigma_moments
 
@@ -126,10 +123,7 @@ def green_high_frequency_moments(density_matrix,
                 op = -_anticomm(_comm(h_imp, c(bl,orb1)), c_dag(bl,orb2))
                 green_moments[bl][2,orb1,orb2] = trace_rho_op(density_matrix, op, ad_imp)
         # enforce hermiticity
-        moments_non_herm = green_moments[bl][2, :, :].copy()
         green_moments[bl][2, :, :] = 0.5*(green_moments[bl][2, :, :] + green_moments[bl][2, :, :].T.conj())
-        if np.linalg.norm(green_moments[bl][2, :, :] - moments_non_herm) > 1e-3:
-            mpi.report('\nWARNING: Hermiticity of Gf moments is enforced, but violation was larger than 1e-3. Probably due to poor statistics.\n')
 
     return green_moments
 


### PR DESCRIPTION
Moments of Gf and Sigma should be hermitian. Not enforcing hermiticity leads to non hermitian Gf when using the moments in Fourier transforms or tail fitting.