### PR TITLE
fix: data type of certain parameters int -> long

### DIFF
--- a/c++/triqs_cthyb/parameters.hpp
+++ b/c++/triqs_cthyb/parameters.hpp
@@ -67,7 +67,7 @@ namespace triqs_cthyb {
     many_body_op_t h_int;
 
     /// Number of QMC cycles
-    int n_cycles;
+    long n_cycles;
 
     /// Partition method
     /// type: str
@@ -88,15 +88,15 @@ namespace triqs_cthyb {
 
     /// Length of a single QMC cycle
     /// default: 50
-    int length_cycle = 50;
+    long length_cycle = 50;
 
     /// Number of cycles for thermalization
     /// default: 5000
-    int n_warmup_cycles = 5000;
+    long n_warmup_cycles = 5000;
 
     /// Seed for random number generator
     /// default: 34788 + 928374 * MPI.rank
-    int random_seed = 34788 + 928374 * mpi::communicator().rank();
+    long random_seed = 34788 + 928374 * mpi::communicator().rank();
 
     /// Name of random number generator
     /// type: str
@@ -104,7 +104,7 @@ namespace triqs_cthyb {
 
     /// Maximum runtime in seconds, use -1 to set infinite
     /// default: -1 = infinite
-    int max_time = -1;
+    long max_time = -1;
 
     /// Verbosity level
     /// default: 3 on MPI rank 0, 0 otherwise.
@@ -230,7 +230,7 @@ namespace triqs_cthyb {
 
     solve_parameters_t() {}
 
-    solve_parameters_t(many_body_op_t h_int, int n_cycles) : h_int(h_int), n_cycles(n_cycles) {}
+    solve_parameters_t(many_body_op_t h_int, long n_cycles) : h_int(h_int), n_cycles(n_cycles) {}
 
     /// Write solve_parameters_t to hdf5
     friend void h5_write(h5::group h5group, std::string subgroup_name, solve_parameters_t const &sp);

--- a/python/triqs_cthyb/solver_core_desc.py
+++ b/python/triqs_cthyb/solver_core_desc.py
@@ -334,7 +334,7 @@ c.add_member(c_name = "h_int",
      type: Operator""")
 
 c.add_member(c_name = "n_cycles",
-             c_type = "int",
+             c_type = "long",
              initializer = """  """,
              doc = r"""Number of QMC cycles""")
 
@@ -364,19 +364,19 @@ c.add_member(c_name = "loc_n_max",
      default: INT_MAX""")
 
 c.add_member(c_name = "length_cycle",
-             c_type = "int",
+             c_type = "long",
              initializer = """ 50 """,
              doc = r"""Length of a single QMC cycle
      default: 50""")
 
 c.add_member(c_name = "n_warmup_cycles",
-             c_type = "int",
+             c_type = "long",
              initializer = """ 5000 """,
              doc = r"""Number of cycles for thermalization
      default: 5000""")
 
 c.add_member(c_name = "random_seed",
-             c_type = "int",
+             c_type = "long",
              initializer = """ 34788+928374*mpi::communicator().rank() """,
              doc = r"""Seed for random number generator
      default: 34788 + 928374 * MPI.rank""")
@@ -388,7 +388,7 @@ c.add_member(c_name = "random_name",
      type: str""")
 
 c.add_member(c_name = "max_time",
-             c_type = "int",
+             c_type = "long",
              initializer = """ -1 """,
              doc = r"""Maximum runtime in seconds, use -1 to set infinite
      default: -1 = infinite""")


### PR DESCRIPTION
Previously it was not possible to sample more than 32 bit number of cycles (2,147,483,647). We should maybe discuss if we want to also change other parameter types. However with https://github.com/TRIQS/cpp2py/pull/46 at least any failing conversions of int / long should be prevented. 