### PR TITLE
add moments to static observables notebooks

### DIFF
--- a/doc/guide/static_observables_notebook.ipynb
+++ b/doc/guide/static_observables_notebook.ipynb
@@ -267,6 +267,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Measuring moments of Green's function and self-energy\n",
+    "The high-frequency moments of the Green's function and self-energy contain crucial high-frequency information that can be used to (1) improve the Fourier transform of the Green's function from imaginary time to Matsubara frequencies and (2) improve the tail fit of the self-energy. When a user turns on the measurement of the dentiy matrix (``measure_density_matrix = True``)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Evaluation of the impurity interaction energy\n",
     "\n",
     "The function `trace_rho_op()` can also be used to evaluate the interaction energy of the impurity by computing the expectation value of $\\hat{H}_\\mathrm{int}$:"
@@ -310,7 +318,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -323,7 +331,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.7"
   }
  },
  "nbformat": 4,

--- a/doc/guide/static_observables_notebook.ipynb
+++ b/doc/guide/static_observables_notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -59,14 +59,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: could not identify MPI environment!\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Starting run with 1 MPI rank(s) at : 2019-11-25 22:04:14.037607\n"
+      "Starting serial run at: 2023-08-14 16:13:15.854417\n"
      ]
     }
    ],
@@ -88,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +109,7 @@
     "\n",
     "# Construct the impurity solver with the inverse temperature\n",
     "# and the structure of the Green's functions\n",
-    "S = Solver(beta = beta, gf_struct = [ ('up',[0]), ('down',[0]) ])\n",
+    "S = Solver(beta = beta, gf_struct = [ ('up',1), ('down',1) ])\n",
     "\n",
     "# Initialize the non-interacting Green's function S.G0_iw\n",
     "# External magnetic field introduces Zeeman energy splitting between\n",
@@ -125,60 +132,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\n",
-      "╔╦╗╦═╗╦╔═╗ ╔═╗  ┌─┐┌┬┐┬ ┬┬ ┬┌┐ \n",
-      " ║ ╠╦╝║║═╬╗╚═╗  │   │ ├─┤└┬┘├┴┐\n",
-      " ╩ ╩╚═╩╚═╝╚╚═╝  └─┘ ┴ ┴ ┴ ┴ └─┘\n",
-      "\n",
-      "The local Hamiltonian of the problem:\n",
-      "-1.995*c_dag('down',0)*c('down',0) + -2.005*c_dag('up',0)*c('up',0) + 4*c_dag('down',0)*c_dag('up',0)*c('up',0)*c('down',0)\n",
-      "Using autopartition algorithm to partition the local Hilbert space\n",
-      "Found 4 subspaces.\n",
-      "\n",
-      "Warming up ...\n",
-      "22:04:14  10% ETA 00:00:00 cycle 1055 of 10000\n",
-      "\n",
-      "\n",
-      "\n",
-      "Accumulating ...\n",
-      "22:04:15   0% ETA 00:00:46 cycle 1063 of 500000\n",
-      "22:04:17   4% ETA 00:00:43 cycle 23190 of 500000\n",
-      "22:04:20  10% ETA 00:00:41 cycle 50917 of 500000\n",
-      "22:04:23  17% ETA 00:00:37 cycle 85400 of 500000\n",
-      "22:04:27  25% ETA 00:00:34 cycle 128456 of 500000\n",
-      "22:04:32  36% ETA 00:00:29 cycle 182170 of 500000\n",
-      "22:04:38  49% ETA 00:00:22 cycle 249867 of 500000\n",
-      "22:04:46  66% ETA 00:00:15 cycle 334334 of 500000\n",
-      "22:04:55  87% ETA 00:00:05 cycle 439976 of 500000\n",
-      "\n",
-      "\n",
-      "[Rank 0] Collect results: Waiting for all mpi-threads to finish accumulating...\n",
-      "[Rank 0] Timings for all measures:\n",
-      "Measure                                    | seconds   \n",
-      "Average sign                               | 0.0164616 \n",
-      "Density Matrix for local static observable | 0.361092  \n",
-      "G_tau measure                              | 0.0531679 \n",
-      "Total measure time                         | 0.430722  \n",
-      "[Rank 0] Acceptance rate for all moves:\n",
-      "Move set Insert two operators: 0.0460374\n",
-      "  Move  Insert Delta_up: 0.0460443\n",
-      "  Move  Insert Delta_down: 0.0460304\n",
-      "Move set Remove two operators: 0.0460288\n",
-      "  Move  Remove Delta_up: 0.0460209\n",
-      "  Move  Remove Delta_down: 0.0460368\n",
-      "Move  Shift one operator: 0.032573\n",
-      "[Rank 0] Warmup lasted: 0.914752 seconds [00:00:00]\n",
-      "[Rank 0] Simulation lasted: 45.8245 seconds [00:00:45]\n",
-      "[Rank 0] Number of measures: 500000\n",
-      "Total number of measures: 500000\n",
-      "Average sign: 1\n"
+      "Insert error : recovering ... \n"
      ]
     }
    ],
@@ -201,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,16 +200,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<N_up> = 0.620367909784\n",
-      "<N_down> =  0.379668700586\n",
-      "<N_up*N_down> = 0.00358171472283\n"
+      "<N_up> = 0.6200042407162714\n",
+      "<N_down> =  0.3801439064667559\n",
+      "<N_up*N_down> = 0.003665497313727422\n"
      ]
     }
    ],
@@ -268,7 +229,52 @@
    "metadata": {},
    "source": [
     "## Measuring moments of Green's function and self-energy\n",
-    "The high-frequency moments of the Green's function and self-energy contain crucial high-frequency information that can be used to (1) improve the Fourier transform of the Green's function from imaginary time to Matsubara frequencies and (2) improve the tail fit of the self-energy. When a user turns on the measurement of the dentiy matrix (``measure_density_matrix = True``)"
+    "The high-frequency moments of the Green's function and self-energy contain crucial high-frequency information that can be used to (1) improve the Fourier transform of the Green's function from imaginary time to Matsubara frequencies and (2) improve the tail fit of the self-energy. When a user turns on the measurement of the density matrix (``measure_density_matrix = True``), these high-frequency moments are automatically calculated and used. \n",
+    "\n",
+    "The moments are stored as members of the ``Solver`` class. ``Solver.Sigma_moments`` are the calculated self-energy moments and ``Solver.G_moments`` are the calculated Green's function moments. For example,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "({'up': array([[[1.52057563+0.j]],\n",
+       "  \n",
+       "         [[3.77015227+0.j]]]),\n",
+       "  'down': array([[[2.48001696+0.j]],\n",
+       "  \n",
+       "         [[3.76958372+0.j]]])},\n",
+       " {'up': array([[[ 0.        +0.j]],\n",
+       "  \n",
+       "         [[ 1.        +0.j]],\n",
+       "  \n",
+       "         [[-0.48442437+0.j]]]),\n",
+       "  'down': array([[[0.        +0.j]],\n",
+       "  \n",
+       "         [[1.        +0.j]],\n",
+       "  \n",
+       "         [[0.48501696+0.j]]])})"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# accessing the high frequency moments stored in the Solver class\n",
+    "S.Sigma_moments, S.G_moments"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The moments are stored as Python dictonaries and have the same structure as ``gf_struct``. For more technical information and details, see the [high frequency moments notebook](high_freq_moments.ipynb)."
    ]
   },
   {
@@ -282,14 +288,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "E_int=<H_int>= 0.0143\n"
+      "E_int=<H_int>= 0.0147\n"
      ]
     }
    ],


### PR DESCRIPTION
In the static observables cthyb tutorial, we add a small reference to the high-frequency moments since this is automatically turned on when a user measures the density matrix. This makes all of the documentation self-consistent.