### PR TITLE
Bug fix in qmc_data

### DIFF
--- a/c++/triqs_cthyb/qmc_data.hpp
+++ b/c++/triqs_cthyb/qmc_data.hpp
@@ -121,6 +121,7 @@ namespace triqs_cthyb {
 
       // initialize hybridization determinants
       dets.clear();
+      dets.reserve(delta.size());
       for (auto const &bl : range(delta.size())) {
 #ifdef HYBRIDISATION_IS_COMPLEX
         auto delta_functor = delta_block_adaptor(delta[bl]);


### PR DESCRIPTION
`This` PR fixes a bug in `qmc_data.hpp` by reserving the vector `dets`.

There might have been a misunderstanding when I said adding this line gave different results. What I meant is that it yields a different outcome. 

Basically, the values of `det_singular_threshold`, `det_n_operations_before_check`, `det_precision_warning`, `det_precision_error` are not set correctly, except for the last block. They are kept to their default value.

The issue is that using `emplace_back` reallocates memory of the elements that have already been inserted in `dets`. Thus, the values of `det_singular_threshold`, `det_n_operations_before_check`, `det_precision_warning` and `det_precision_error` that have been set for the previous blocks are erased, and set to their default values. The variable `dets` needs to be reserved to prevent that.

A minimal example is simple. Take a system with at least two blocks. Try to set a non-default value for any of the 4 variables I mentioned via solve_parameters. Print the value of the said variable after the loop over the blocks in `qmc_data.hpp`, and see that it is the default value, and not the value you input.

