### PR TITLE
Fix upper bound in lazy trace evaluation

### DIFF
--- a/c++/triqs_cthyb/impurity_trace.cpp
+++ b/c++/triqs_cthyb/impurity_trace.cpp
@@ -342,9 +342,9 @@ namespace triqs_cthyb {
     bound_cumul[n_bl] = 0;
     if (!use_norm_as_weight) {
       for (int bl = n_bl - 1; bl >= 0; --bl)
-        bound_cumul[bl] = bound_cumul[bl + 1] + std::exp(-to_sort_lnorm_b[bl].first) * std::sqrt(get_block_dim(to_sort_lnorm_b[bl].second));
+        bound_cumul[bl] = bound_cumul[bl + 1] + std::exp(-to_sort_lnorm_b[bl].first) * get_block_dim(to_sort_lnorm_b[bl].second);
     } else {
-      for (int bl = n_bl - 1; bl >= 0; --bl) bound_cumul[bl] = bound_cumul[bl + 1] + std::exp(-to_sort_lnorm_b[bl].first);
+      for (int bl = n_bl - 1; bl >= 0; --bl) bound_cumul[bl] = bound_cumul[bl + 1] + std::exp(-to_sort_lnorm_b[bl].first) * std::sqrt(get_block_dim(to_sort_lnorm_b[bl].second));
     }
 
     int bl;


### PR DESCRIPTION
This PR fixes a bug in the computation of the upper bound in the lazy trace formula.

You use the formula $|Tr(M)| \le \lVert M \rVert \times \sqrt{N}$, with N the dimension of $M = M_1 \times... \times M_k$. However, this is only true when ||.|| is the Frobenius norm. When using the spectral norm, this is $|Tr(M)| \le \lVert M \rVert \times N$.

The norm that is used in practice is a combination of Frobenius norm $\lVert . \rVert_F$ and spectral norm $\lVert . \rVert_2$ 
such as : $\lVert M_1 \times ... \times M_i  \rVert_F  \lVert M_{i+1}\rVert_2  \times ... \times \lvert M_j  \rVert_2  \lVert M_{j+1} \times ... \times M_k  \rVert_F$ for instance, depending on what is available in cache.  

Thus the only rigorous way to compute the upper bound is: $|Tr(M)| \le \lVert M_1 \times ... \times M_i  \rVert_2  \lVert M_{i+1} \times ... \times M_j  \rVert_2  \lVert M_{j+1} \times ... \times M_k  \rVert_2 \times N \le \lVert M_1 \times ... \times M_i  \rVert_F  \lVert M_{i+1} \rVert_2 \times ... \times \lvert M_j  \rVert_2  \lVert M_{j+1} \times ... \times M_k  \rVert_F \times N = \lVert M \rVert \times N$, where I used the inequality $\lVert M \rVert_2 \le \lVert M \rVert_F$. 

Likewise when using the norm instead of the trace as weight. There is an additional square root.

