### PR TITLE
Register triqs.stat.histograms converter on import

### DIFF
--- a/python/triqs_cthyb/__init__.py
+++ b/python/triqs_cthyb/__init__.py
@@ -23,6 +23,8 @@ r"""
 DOC
 
 """
+# triqs::stat::histogram so that Solver.perturbation_order(_total) and performance_analysis can be used
+from triqs.stat.histograms import Histogram
 from .solver import Solver
 from .solver_core import SolverCore, ConstrParametersT, SolveParametersT
 from .configuration import Configuration, OpDesc

--- a/test/python/histograms.py
+++ b/test/python/histograms.py
@@ -4,7 +4,6 @@ import triqs.utility.mpi as mpi
 from h5 import HDFArchive
 from triqs.operators import *
 from triqs_cthyb import *
-from triqs.stat.histograms import Histogram
 from triqs.gfs import *
 import numpy as np
 


### PR DESCRIPTION
## Problem

Accessing `Solver.perturbation_order`, `Solver.perturbation_order_total`, or `Solver.performance_analysis` returns a `dict[str, triqs::stat::histogram]`. The c2py converter for `triqs::stat::histogram` is only registered when `triqs.stat.histograms` is imported, but `triqs_cthyb` never imported it. Any caller that didn't import it themselves hit:

```
RuntimeError: The type N5triqs4stat9histogramE can not be converted
```

This surfaced downstream in solid_dmft (`measure_pert_order = True`), which reads `perturbation_order` after a solve without importing `triqs.stat.histograms`.

## Fix

Import `triqs.stat.histograms` in `triqs_cthyb/__init__.py` so the converter is always registered for any consumer of the package.

## Why the test suite missed it

`test/python/histograms.py` exercises this exact path, but imported `triqs.stat.histograms` itself, which masked the missing import — it passed for the wrong reason. This PR removes that import from the test so it runs as a regular caller would. Verified the test fails without the `__init__.py` change and passes with it (`ctest -R histograms`).